### PR TITLE
Integrate content moderation components into a functional plugin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,17 +7,18 @@ toolchain go1.22.8
 require (
 	github.com/mattermost/mattermost/server/public v0.1.10
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.10.0
 )
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/sirupsen/logrus v1.9.3 // indirect
 )
 
 require (
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dyatlov/go-opengraph/opengraph v0.0.0-20220524092352-606d7b1e5f8a // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/francoispqt/gojay v1.2.13 // indirect
@@ -39,7 +40,9 @@ require (
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tinylib/msgp v1.2.5 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -168,8 +168,6 @@ github.com/shurcooL/reactions v0.0.0-20181006231557-f2e0b4ca5b82/go.mod h1:TCR1l
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20170918181015-86672fcb3f95/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/users v0.0.0-20180125191416-49c67e49c537/go.mod h1:QJTqeLYEDaXHZDBsXlPCDqdhQuJkuw4NOtaxYe3xii4=
 github.com/shurcooL/webdavfs v0.0.0-20170829043945-18c3829fa133/go.mod h1:hKmq5kWdCj2z2KEozexVbfEZIWiTjhE0+UjmZgPqehw=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/sourcegraph/annotate v0.0.0-20160123013949-f4cad6c6324d/go.mod h1:UdhH50NIW0fCiwBSr0co2m7BnFLdv4fQTgdqdJTHFeE=
 github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod h1:HuIsMU8RRBOtsCgI77wP899iHVBQpCmg4ErYMZB+2IA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
@@ -177,7 +175,6 @@ github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
 github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
@@ -248,7 +245,6 @@ golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -121,5 +121,11 @@ func (p *Plugin) OnConfigurationChange() error {
 
 	p.setConfiguration(configuration)
 
+	// Initialize or reinitialize the moderator with the new configuration
+	if err := p.initialize(); err != nil {
+		p.API.LogError("Failed to reinitialize after configuration change", "err", err)
+		return errors.Wrap(err, "failed to reinitialize")
+	}
+
 	return nil
 }

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+func (p *Plugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {
+	p.processor.queuePostForProcessing(post)
+}
+
+func (p *Plugin) MessageHasBeenUpdated(c *plugin.Context, post, _ *model.Post) {
+	p.processor.queuePostForProcessing(post)
+}

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -2,29 +2,87 @@ package main
 
 import (
 	"sync"
+	"time"
 
+	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
+	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation/azure"
 	"github.com/mattermost/mattermost/server/public/plugin"
-	"github.com/mattermost/mattermost/server/public/pluginapi"
+	"github.com/pkg/errors"
 )
 
-// Plugin implements the interface expected by the Mattermost server to communicate between the server and plugin processes.
+const moderationTimeout = 10 * time.Second
+
 type Plugin struct {
 	plugin.MattermostPlugin
 
-	// client is the Mattermost server API client.
-	client *pluginapi.Client
-
-	// configurationLock synchronizes access to the configuration.
 	configurationLock sync.RWMutex
+	configuration     *configuration
 
-	// configuration is the active plugin configuration. Consult getConfiguration and
-	// setConfiguration for usage.
-	configuration *configuration
+	processor *PostProcessor
 }
 
-// OnActivate is invoked when the plugin is activated. If an error is returned, the plugin will be deactivated.
 func (p *Plugin) OnActivate() error {
-	p.client = pluginapi.NewClient(p.API, p.Driver)
+	return p.initialize()
+}
+
+func (p *Plugin) initialize() error {
+	if p.processor != nil {
+		p.processor.stop()
+		p.processor = nil
+	}
+
+	config := p.getConfiguration()
+	if !config.Enabled {
+		p.API.LogInfo("Content moderation is disabled")
+		return nil
+	}
+
+	targetUsers := config.ModerationTargetsList()
+	if len(targetUsers) == 0 && !config.ModerateAllUsers {
+		p.API.LogInfo("Content moderation is targeting no users")
+		return nil
+	}
+
+	thresholdValue, err := config.ThresholdValue()
+	if err != nil {
+		p.API.LogError("failed to load moderation threshold", "err", err)
+		return errors.Wrap(err, "failed to load moderation threshold")
+	}
+
+	moderator, err := initModerator(p.API, config)
+	if err != nil {
+		return errors.Wrap(err, "failed to initialize moderator")
+	}
+
+	processor, err := newPostProcessor(
+		moderator, thresholdValue, config.ModerateAllUsers, targetUsers)
+	if err != nil {
+		p.API.LogError("failed to create post processor", "err", err)
+		return errors.Wrap(err, "failed to create post processor")
+	}
+	p.processor = processor
+	p.processor.start(p.API)
 
 	return nil
+}
+
+func initModerator(api plugin.API, config *configuration) (moderation.Moderator, error) {
+	switch config.Type {
+	case "azure":
+		azureConfig := &moderation.Config{
+			Endpoint: config.Endpoint,
+			APIKey:   config.APIKey,
+		}
+
+		mod, err := azure.New(azureConfig)
+		if err != nil {
+			api.LogError("failed to create Azure moderator", "err", err)
+			return nil, errors.Wrap(err, "failed to create Azure moderator")
+		}
+
+		api.LogInfo("Azure AI Content Safety moderator initialized")
+		return mod, nil
+	default:
+		return nil, errors.Errorf("unknown moderator type: %s", config.Type)
+	}
 }

--- a/server/processor.go
+++ b/server/processor.go
@@ -1,0 +1,164 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/pkg/errors"
+)
+
+const postsPerMinuteLimit = 500
+const processingInterval = 1 / postsPerMinuteLimit * time.Minute
+
+var (
+	ErrModerationRejection   = errors.New("potentially inappropriate content detected")
+	ErrModerationUnavailable = errors.New("moderation service is not available")
+)
+
+type PostProcessor struct {
+	moderator moderation.Moderator
+
+	stopChan chan bool
+
+	thresholdValue int
+	targetAll      bool
+	targetUsers    map[string]struct{}
+
+	postsToProcess []*model.Post
+	processLock    sync.Mutex
+}
+
+func newPostProcessor(
+	moderator moderation.Moderator,
+	thresholdValue int,
+	targetAll bool,
+	targetUsers map[string]struct{},
+) (*PostProcessor, error) {
+	if moderator == nil {
+		return nil, ErrModerationUnavailable
+	}
+	return &PostProcessor{
+		moderator:      moderator,
+		stopChan:       make(chan bool, 1),
+		thresholdValue: thresholdValue,
+		targetAll:      targetAll,
+		targetUsers:    targetUsers,
+	}, nil
+}
+
+func (p *PostProcessor) start(api plugin.API) {
+	go func() {
+		for {
+			select {
+			case <-p.stopChan:
+				return
+			default:
+			}
+
+			time.Sleep(processingInterval)
+
+			post := p.popPostForProcessing()
+			if post == nil {
+				continue
+			}
+
+			err := p.moderatePost(api, post)
+			if err == nil {
+				continue
+			}
+
+			if errors.Is(err, ErrModerationUnavailable) {
+				api.LogError("Content moderation error", "err", err, "post_id", post.Id, "user_id", post.UserId)
+				continue
+			}
+
+			if err := api.DeletePost(post.Id); err != nil {
+				api.LogError("Failed to delete post flagged by content moderation", "post_id", post.Id, "err", err)
+			}
+		}
+	}()
+}
+
+func (p *PostProcessor) stop() {
+	p.stopChan <- true
+}
+
+func (p *PostProcessor) queuePostForProcessing(post *model.Post) {
+	p.processLock.Lock()
+	defer p.processLock.Unlock()
+
+	p.postsToProcess = append(p.postsToProcess, post)
+}
+
+func (p *PostProcessor) popPostForProcessing() *model.Post {
+	p.processLock.Lock()
+	defer p.processLock.Unlock()
+
+	if len(p.postsToProcess) == 0 {
+		return nil
+	}
+
+	post := p.postsToProcess[0]
+	p.postsToProcess = p.postsToProcess[1:]
+
+	return post
+}
+
+func (p *PostProcessor) moderatePost(api plugin.API, post *model.Post) error {
+	if !p.shouldModerateUser(post.UserId) {
+		return nil
+	}
+
+	if post.Message == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), moderationTimeout)
+	defer cancel()
+
+	result, err := p.moderator.ModerateText(ctx, post.Message)
+	if err != nil {
+		return ErrModerationUnavailable
+	}
+
+	if p.resultSeverityAboveThreshold(result) {
+		p.logFlaggedResult(api, post.UserId, result)
+		return ErrModerationRejection
+	}
+
+	return nil
+}
+
+func (p *PostProcessor) shouldModerateUser(userID string) bool {
+	if p.targetAll {
+		return true
+	}
+	_, exists := p.targetUsers[userID]
+	return exists
+}
+
+func (p *PostProcessor) resultSeverityAboveThreshold(result moderation.Result) bool {
+	for _, severity := range result {
+		if severity >= p.thresholdValue {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *PostProcessor) logFlaggedResult(api plugin.API, userID string, result moderation.Result) {
+	keyPairs := []any{"user_id", userID, "threshold", p.thresholdValue}
+
+	for category, severity := range result {
+		if severity >= p.thresholdValue {
+			keyPairs = append(keyPairs, category)
+			keyPairs = append(keyPairs, severity)
+		}
+	}
+
+	api.LogInfo("Content was flagged by moderation", keyPairs...)
+}

--- a/server/processor.go
+++ b/server/processor.go
@@ -11,6 +11,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// The current Azure rate limit is 1000 posts per minute.
+// Using half of that to give us some wiggle room:
+// https://learn.microsoft.com/en-us/azure/ai-services/content-safety/faq
 const postsPerMinuteLimit = 500
 const processingInterval = 1 / postsPerMinuteLimit * time.Minute
 

--- a/server/processor_test.go
+++ b/server/processor_test.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockModerator is a mock implementation of the Moderator interface
+type MockModerator struct {
+	mock.Mock
+}
+
+func (m *MockModerator) ModerateText(ctx context.Context, text string) (moderation.Result, error) {
+	args := m.Called(ctx, text)
+	return args.Get(0).(moderation.Result), args.Error(1)
+}
+
+func TestResultSeverityAboveThreshold(t *testing.T) {
+	tests := []struct {
+		name           string
+		result         moderation.Result
+		thresholdValue int
+		expected       bool
+	}{
+		{
+			name: "All severities below threshold",
+			result: moderation.Result{
+				"hate":     20,
+				"sexual":   15,
+				"violence": 30,
+			},
+			thresholdValue: 50,
+			expected:       false,
+		},
+		{
+			name: "One severity above threshold",
+			result: moderation.Result{
+				"hate":     20,
+				"sexual":   75,
+				"violence": 30,
+			},
+			thresholdValue: 50,
+			expected:       true,
+		},
+		{
+			name: "Multiple severities above threshold",
+			result: moderation.Result{
+				"hate":     60,
+				"sexual":   75,
+				"violence": 80,
+			},
+			thresholdValue: 50,
+			expected:       true,
+		},
+		{
+			name: "Severity equal to threshold",
+			result: moderation.Result{
+				"hate":     20,
+				"sexual":   50,
+				"violence": 30,
+			},
+			thresholdValue: 50,
+			expected:       true,
+		},
+		{
+			name:           "Empty result",
+			result:         moderation.Result{},
+			thresholdValue: 50,
+			expected:       false,
+		},
+		{
+			name: "Zero threshold",
+			result: moderation.Result{
+				"hate": 1,
+			},
+			thresholdValue: 0,
+			expected:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor := &PostProcessor{
+				thresholdValue: tt.thresholdValue,
+			}
+
+			result := processor.resultSeverityAboveThreshold(tt.result)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestQueueAndPopPost(t *testing.T) {
+	t.Run("Queue and pop single post", func(t *testing.T) {
+		processor := &PostProcessor{}
+		post := &model.Post{Id: "post1", Message: "Test message"}
+
+		// Queue a post
+		processor.queuePostForProcessing(post)
+
+		// Verify it's in the queue
+		assert.Len(t, processor.postsToProcess, 1)
+		assert.Equal(t, post, processor.postsToProcess[0])
+
+		// Pop the post and verify it's the same
+		poppedPost := processor.popPostForProcessing()
+		assert.Equal(t, post, poppedPost)
+
+		// Verify queue is now empty
+		assert.Empty(t, processor.postsToProcess)
+
+		// Verify popping from empty queue returns nil
+		emptyPost := processor.popPostForProcessing()
+		assert.Nil(t, emptyPost)
+	})
+
+	t.Run("Queue and pop multiple posts in FIFO order", func(t *testing.T) {
+		processor := &PostProcessor{}
+		post1 := &model.Post{Id: "post1", Message: "First message"}
+		post2 := &model.Post{Id: "post2", Message: "Second message"}
+		post3 := &model.Post{Id: "post3", Message: "Third message"}
+
+		// Queue posts
+		processor.queuePostForProcessing(post1)
+		processor.queuePostForProcessing(post2)
+		processor.queuePostForProcessing(post3)
+
+		// Verify queue length
+		assert.Len(t, processor.postsToProcess, 3)
+
+		// Verify posts are popped in FIFO order (first in, first out)
+		assert.Equal(t, post1, processor.popPostForProcessing())
+		assert.Equal(t, post2, processor.popPostForProcessing())
+		assert.Equal(t, post3, processor.popPostForProcessing())
+
+		// Verify queue is now empty
+		assert.Empty(t, processor.postsToProcess)
+	})
+
+	t.Run("Thread safety of queue operations", func(t *testing.T) {
+		processor := &PostProcessor{}
+		const numPosts = 20
+		var wg sync.WaitGroup
+
+		// Create a bunch of posts
+		posts := make([]*model.Post, numPosts)
+		for i := 0; i < numPosts; i++ {
+			posts[i] = &model.Post{Id: fmt.Sprintf("post%d", i), Message: fmt.Sprintf("Message %d", i)}
+		}
+
+		// Queue them from multiple goroutines
+		wg.Add(numPosts)
+		for i := 0; i < numPosts; i++ {
+			go func(idx int) {
+				defer wg.Done()
+				processor.queuePostForProcessing(posts[idx])
+			}(i)
+		}
+		wg.Wait()
+
+		// Verify all posts were queued
+		assert.Len(t, processor.postsToProcess, numPosts)
+
+		// Pop them from multiple goroutines
+		poppedPosts := make([]*model.Post, 0, numPosts)
+		var popMutex sync.Mutex
+
+		wg.Add(numPosts)
+		for i := 0; i < numPosts; i++ {
+			go func() {
+				defer wg.Done()
+				post := processor.popPostForProcessing()
+				if post != nil {
+					popMutex.Lock()
+					poppedPosts = append(poppedPosts, post)
+					popMutex.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+
+		// Verify we got all posts back (though not necessarily in order due to concurrency)
+		assert.Len(t, poppedPosts, numPosts)
+		assert.Empty(t, processor.postsToProcess)
+	})
+}
+
+func TestShouldModerateUser(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetAll   bool
+		targetUsers map[string]struct{}
+		userID      string
+		expected    bool
+	}{
+		{
+			name:        "Target all users",
+			targetAll:   true,
+			targetUsers: map[string]struct{}{},
+			userID:      "any_user",
+			expected:    true,
+		},
+		{
+			name:        "Target specific user - match",
+			targetAll:   false,
+			targetUsers: map[string]struct{}{"user1": {}, "user2": {}},
+			userID:      "user1",
+			expected:    true,
+		},
+		{
+			name:        "Target specific user - no match",
+			targetAll:   false,
+			targetUsers: map[string]struct{}{"user1": {}, "user2": {}},
+			userID:      "user3",
+			expected:    false,
+		},
+		{
+			name:        "Empty target list",
+			targetAll:   false,
+			targetUsers: map[string]struct{}{},
+			userID:      "any_user",
+			expected:    false,
+		},
+		{
+			name:        "Target all and specific users",
+			targetAll:   true,
+			targetUsers: map[string]struct{}{"user1": {}, "user2": {}},
+			userID:      "user3",
+			expected:    true, // targetAll takes precedence
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor := &PostProcessor{
+				targetAll:   tt.targetAll,
+				targetUsers: tt.targetUsers,
+			}
+
+			result := processor.shouldModerateUser(tt.userID)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Only test the simple cases to avoid race conditions in the test
+func TestModeratePost(t *testing.T) {
+	t.Run("Skip moderation for non-targeted user", func(t *testing.T) {
+		mockAPI := &plugintest.API{}
+		mockModerator := &MockModerator{}
+
+		processor := &PostProcessor{
+			moderator:   mockModerator,
+			targetAll:   false,
+			targetUsers: map[string]struct{}{"user1": {}, "user2": {}},
+		}
+
+		post := &model.Post{UserId: "user3", Message: "Test message"}
+		err := processor.moderatePost(mockAPI, post)
+
+		assert.NoError(t, err)
+		mockModerator.AssertNotCalled(t, "ModerateText")
+	})
+
+	t.Run("Skip moderation for empty message", func(t *testing.T) {
+		mockAPI := &plugintest.API{}
+		mockModerator := &MockModerator{}
+
+		processor := &PostProcessor{
+			moderator: mockModerator,
+			targetAll: true,
+		}
+
+		post := &model.Post{UserId: "user1", Message: ""}
+		err := processor.moderatePost(mockAPI, post)
+
+		assert.NoError(t, err)
+		mockModerator.AssertNotCalled(t, "ModerateText")
+	})
+
+	t.Run("Moderation API failure", func(t *testing.T) {
+		mockAPI := &plugintest.API{}
+		mockAPI.On("LogError", mock.Anything, mock.Anything, mock.Anything).Return()
+
+		mockModerator := &MockModerator{}
+		mockModerator.On("ModerateText", mock.Anything, "Test message").
+			Return(moderation.Result{}, errors.New("API error"))
+
+		processor := &PostProcessor{
+			moderator:      mockModerator,
+			targetAll:      true,
+			thresholdValue: 50,
+		}
+
+		post := &model.Post{UserId: "user1", Message: "Test message"}
+		err := processor.moderatePost(mockAPI, post)
+
+		assert.Equal(t, ErrModerationUnavailable, err)
+		mockModerator.AssertExpectations(t)
+	})
+
+	t.Run("Content below threshold", func(t *testing.T) {
+		mockAPI := &plugintest.API{}
+
+		mockModerator := &MockModerator{}
+		mockModerator.On("ModerateText", mock.Anything, "Test message").
+			Return(moderation.Result{"category": 10}, nil)
+
+		processor := &PostProcessor{
+			moderator:      mockModerator,
+			targetAll:      true,
+			thresholdValue: 50,
+		}
+
+		post := &model.Post{UserId: "user1", Message: "Test message"}
+		err := processor.moderatePost(mockAPI, post)
+
+		assert.NoError(t, err)
+		mockModerator.AssertExpectations(t)
+	})
+
+	t.Run("Content above threshold", func(t *testing.T) {
+		mockAPI := &plugintest.API{}
+		mockAPI.On("LogInfo", "Content was flagged by moderation",
+			"user_id", "user1", "threshold", 50, "sexual", 80).Return()
+
+		mockModerator := &MockModerator{}
+		mockModerator.On("ModerateText", mock.Anything, "Inappropriate content").
+			Return(moderation.Result{
+				"hate":     10,
+				"sexual":   80, // Above threshold
+				"violence": 30,
+			}, nil)
+
+		processor := &PostProcessor{
+			moderator:      mockModerator,
+			targetAll:      true,
+			thresholdValue: 50,
+		}
+
+		post := &model.Post{UserId: "user1", Message: "Inappropriate content"}
+		err := processor.moderatePost(mockAPI, post)
+
+		assert.Equal(t, ErrModerationRejection, err) // Should return rejection error
+		mockModerator.AssertExpectations(t)
+		mockAPI.AssertExpectations(t)
+	})
+}
+
+func TestNewPostProcessor(t *testing.T) {
+	tests := []struct {
+		name           string
+		moderator      moderation.Moderator
+		thresholdValue int
+		targetAll      bool
+		targetUsers    map[string]struct{}
+		wantErr        bool
+		expectedErr    error
+	}{
+		{
+			name:           "Valid moderator with thresholds",
+			moderator:      &MockModerator{},
+			thresholdValue: 75,
+			targetAll:      true,
+			targetUsers:    map[string]struct{}{"user1": {}},
+			wantErr:        false,
+		},
+		{
+			name:           "Nil moderator",
+			moderator:      nil,
+			thresholdValue: 75,
+			targetAll:      true,
+			targetUsers:    map[string]struct{}{"user1": {}},
+			wantErr:        true,
+			expectedErr:    ErrModerationUnavailable,
+		},
+		{
+			name:           "Zero threshold",
+			moderator:      &MockModerator{},
+			thresholdValue: 0,
+			targetAll:      false,
+			targetUsers:    map[string]struct{}{"user1": {}},
+			wantErr:        false,
+		},
+		{
+			name:           "No target users",
+			moderator:      &MockModerator{},
+			thresholdValue: 75,
+			targetAll:      false,
+			targetUsers:    map[string]struct{}{},
+			wantErr:        false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			processor, err := newPostProcessor(tt.moderator, tt.thresholdValue, tt.targetAll, tt.targetUsers)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				if tt.expectedErr != nil {
+					assert.Equal(t, tt.expectedErr, err)
+				}
+				assert.Nil(t, processor)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, processor)
+				assert.Equal(t, tt.moderator, processor.moderator)
+				assert.Equal(t, tt.thresholdValue, processor.thresholdValue)
+				assert.Equal(t, tt.targetAll, processor.targetAll)
+				assert.Equal(t, tt.targetUsers, processor.targetUsers)
+				assert.NotNil(t, processor.stopChan)
+				assert.Empty(t, processor.postsToProcess)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Overview

This PR integrates the previously implemented Azure Content Safety moderator with the plugin architecture to moderate post content.

With this change, when posts are created or updated, they are added to a queue of posts to be processed by the moderator. If a post fails moderation, it is deleted.

In a future change, a bot will additionally notify users of this deletion.

## Demo
[moderate.webm](https://github.com/user-attachments/assets/3fe904d7-4eef-40b1-af04-9bfe11d1a3b4)