### PR TITLE
Add a notification system for moderated content

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -71,6 +71,14 @@
                 "help_text": "If not moderating all users, the plugin moderates content from these User IDs."
             },
             {
+                "key": "botUsername",
+                "display_name": "Bot Username",
+                "type": "text",
+                "help_text": "The username that will be displayed for moderation notifications.",
+                "placeholder": "moderator",
+                "default": "moderator"
+            },
+            {
                 "key": "azure_threshold",
                 "display_name": "Azure Moderation Threshold",
                 "type": "dropdown",

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -20,14 +20,15 @@ import (
 // If you add non-reference types to your configuration struct, be sure to rewrite Clone as a deep
 // copy appropriate for your types.
 type configuration struct {
-	Enabled  bool   `json:"enabled"`
-	Type     string `json:"type"`
-	Endpoint string `json:"azure_endpoint"`
-	APIKey   string `json:"azure_apiKey"`
-
+	Enabled           bool   `json:"enabled"`
 	ModerationTargets string `json:"moderationTargets"`
 	ModerateAllUsers  bool   `json:"moderateAllUsers"`
+	BotUsername       string `json:"botUsername"`
 
+	Type string `json:"type"`
+
+	Endpoint  string `json:"azure_endpoint"`
+	APIKey    string `json:"azure_apiKey"`
 	Threshold string `json:"azure_threshold"`
 }
 
@@ -105,7 +106,8 @@ func (p *Plugin) setConfiguration(configuration *configuration) {
 		"moderationEnabled", configuration.Enabled,
 		"moderationAllUsers", configuration.ModerateAllUsers,
 		"moderationTargets", configuration.ModerationTargets,
-		"moderationThreshold", configuration.Threshold)
+		"moderationThreshold", configuration.Threshold,
+		"botUsername", configuration.BotUsername)
 
 	p.configuration = configuration
 }

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
 	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation/azure"
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/pkg/errors"
 )
@@ -37,6 +38,11 @@ func (p *Plugin) initialize() error {
 		return nil
 	}
 
+	botID, err := p.API.EnsureBotUser(&model.Bot{Username: config.BotUsername})
+	if err != nil {
+		return errors.Wrap(err, "could not initialize bot user")
+	}
+
 	targetUsers := config.ModerationTargetsList()
 	if len(targetUsers) == 0 && !config.ModerateAllUsers {
 		p.API.LogInfo("Content moderation is targeting no users")
@@ -55,7 +61,7 @@ func (p *Plugin) initialize() error {
 	}
 
 	processor, err := newPostProcessor(
-		moderator, thresholdValue, config.ModerateAllUsers, targetUsers)
+		botID, moderator, thresholdValue, config.ModerateAllUsers, targetUsers)
 	if err != nil {
 		p.API.LogError("failed to create post processor", "err", err)
 		return errors.Wrap(err, "failed to create post processor")

--- a/server/processor_test.go
+++ b/server/processor_test.go
@@ -359,6 +359,7 @@ func TestModeratePost(t *testing.T) {
 func TestNewPostProcessor(t *testing.T) {
 	tests := []struct {
 		name           string
+		botID          string
 		moderator      moderation.Moderator
 		thresholdValue int
 		targetAll      bool
@@ -368,6 +369,7 @@ func TestNewPostProcessor(t *testing.T) {
 	}{
 		{
 			name:           "Valid moderator with thresholds",
+			botID:          "bot123",
 			moderator:      &MockModerator{},
 			thresholdValue: 75,
 			targetAll:      true,
@@ -376,6 +378,7 @@ func TestNewPostProcessor(t *testing.T) {
 		},
 		{
 			name:           "Nil moderator",
+			botID:          "bot123",
 			moderator:      nil,
 			thresholdValue: 75,
 			targetAll:      true,
@@ -385,6 +388,7 @@ func TestNewPostProcessor(t *testing.T) {
 		},
 		{
 			name:           "Zero threshold",
+			botID:          "bot123",
 			moderator:      &MockModerator{},
 			thresholdValue: 0,
 			targetAll:      false,
@@ -393,6 +397,7 @@ func TestNewPostProcessor(t *testing.T) {
 		},
 		{
 			name:           "No target users",
+			botID:          "bot123",
 			moderator:      &MockModerator{},
 			thresholdValue: 75,
 			targetAll:      false,
@@ -403,7 +408,7 @@ func TestNewPostProcessor(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			processor, err := newPostProcessor(tt.moderator, tt.thresholdValue, tt.targetAll, tt.targetUsers)
+			processor, err := newPostProcessor(tt.botID, tt.moderator, tt.thresholdValue, tt.targetAll, tt.targetUsers)
 
 			if tt.wantErr {
 				assert.Error(t, err)
@@ -414,6 +419,7 @@ func TestNewPostProcessor(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, processor)
+				assert.Equal(t, tt.botID, processor.botID)
 				assert.Equal(t, tt.moderator, processor.moderator)
 				assert.Equal(t, tt.thresholdValue, processor.thresholdValue)
 				assert.Equal(t, tt.targetAll, processor.targetAll)


### PR DESCRIPTION
## Overview
Users now receive direct messages from a bot about their removed posts, while channels get a discreet notification. The bot username is configurable in the system console.

## Demo
[moderator-notify.webm](https://github.com/user-attachments/assets/eeadbe66-754a-4295-b157-d8ce11b5dc2c)
