### PR TITLE
Rename to Mattermost Content Moderation Plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **IMPORTANT**: This CLAUDE.md file MUST be kept up to date whenever code changes are made, with NO EXCEPTIONS. Any changes to the codebase should be reflected in this document.
 
 ## Project Context
-This repository contains a Mattermost Content Moderator plugin that provides automatic content moderation using Azure AI Content Safety APIs. Key features:
+This repository contains a Mattermost Content Moderation plugin that provides automatic content moderation using Azure AI Content Safety APIs. Key features:
 
 - Text content moderation (hate speech, sexual, violence, self-harm)
 - Configurable single moderation threshold

--- a/Makefile
+++ b/Makefile
@@ -406,5 +406,5 @@ help:
 mock:
 ifneq ($(HAS_SERVER),)
 	go install github.com/golang/mock/mockgen@v1.6.0
-	mockgen -destination=server/command/mocks/mock_commands.go -package=mocks github.com/mattermost/mattermost-plugin-content-moderator/server/command Command
+	mockgen -destination=server/command/mocks/mock_commands.go -package=mocks github.com/mattermost/mattermost-plugin-content-moderation/server/command Command
 endif

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Mattermost Content Moderator Plugin
+# Mattermost Content Moderation Plugin
 
-[![Build Status](https://github.com/mattermost/mattermost-plugin-content-moderator/actions/workflows/ci.yml/badge.svg)](https://github.com/mattermost/mattermost-plugin-content-moderator/actions/workflows/ci.yml)
+[![Build Status](https://github.com/mattermost/mattermost-plugin-content-moderation/actions/workflows/ci.yml/badge.svg)](https://github.com/mattermost/mattermost-plugin-content-moderation/actions/workflows/ci.yml)
 
 This plugin provides content moderation capabilities for Mattermost using Azure AI Content Safety APIs.
 
 ## Overview
 
-The Content Moderator Plugin allows Mattermost administrators to ensure all content shared on the platform meets community guidelines by automatically moderating messages and attachments.
+The Content Moderation Plugin allows Mattermost administrators to ensure all content shared on the platform meets community guidelines by automatically moderating messages and attachments.
 
 Key features:
 - Text content moderation (hate speech, sexual content, violence, self-harm)
@@ -16,7 +16,7 @@ Key features:
 
 ## Installation
 
-1. Download the latest release from the [releases page](https://github.com/mattermost/mattermost-plugin-content-moderator/releases)
+1. Download the latest release from the [releases page](https://github.com/mattermost/mattermost-plugin-content-moderation/releases)
 2. Upload the plugin to your Mattermost instance via System Console > Plugin Management
 3. Enable the plugin
 4. Configure the plugin with your Azure AI Content Safety API key and settings
@@ -51,14 +51,6 @@ The plugin intercepts messages before they are posted to the database using Matt
 4. If content passes moderation checks, the message is allowed through normally.
 
 The plugin uses a "fail-closed" approach - if the moderation service encounters an error, content is blocked by default for safety.
-
-## AI Plugin Integration
-
-This plugin is designed to work with the Mattermost AI Plugin, particularly for moderating AI-generated responses. For proper integration:
-
-1. Install both the Content Moderator Plugin and the AI Plugin
-2. Configure the AI Plugin to disable streaming responses
-3. Add the AI bot user ID to the moderation targets list in the Content Moderator Plugin
 
 ## Development
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattermost/mattermost-plugin-content-moderator
+module github.com/mattermost/mattermost-plugin-content-moderation
 
 go 1.22.0
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
-    "id": "com.mattermost.content-moderator",
-    "name": "Content Moderator",
+    "id": "com.mattermost.content-moderation",
+    "name": "Content Moderation",
     "description": "This plugin provides content moderation capabilities using Azure AI Content Safety APIs.",
-    "homepage_url": "https://github.com/mattermost/mattermost-plugin-content-moderator",
-    "support_url": "https://github.com/mattermost/mattermost-plugin-content-moderator/issues",
+    "homepage_url": "https://github.com/mattermost/mattermost-plugin-content-moderation",
+    "support_url": "https://github.com/mattermost/mattermost-plugin-content-moderation/issues",
     "icon_path": "assets/content-moderator-icon.svg",
     "min_server_version": "6.2.1",
     "server": {
@@ -19,8 +19,8 @@
         "bundle_path": "webapp/dist/main.js"
     },
     "settings_schema": {
-        "header": "Configure the Content Moderator plugin.",
-        "footer": "* To report an issue, make a suggestion, or contribute, [check the repository](https://github.com/mattermost/mattermost-plugin-content-moderator).",
+        "header": "Configure the Content Moderation plugin.",
+        "footer": "* To report an issue, make a suggestion, or contribute, [check the repository](https://github.com/mattermost/mattermost-plugin-content-moderation).",
         "settings": [
             {
                 "key": "enabled",

--- a/server/moderation/azure/azure.go
+++ b/server/moderation/azure/azure.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
+	"github.com/mattermost/mattermost-plugin-content-moderation/server/moderation"
 	"github.com/pkg/errors"
 )
 

--- a/server/plugin.go
+++ b/server/plugin.go
@@ -4,8 +4,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
-	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation/azure"
+	"github.com/mattermost/mattermost-plugin-content-moderation/server/moderation"
+	"github.com/mattermost/mattermost-plugin-content-moderation/server/moderation/azure"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/pkg/errors"

--- a/server/processor.go
+++ b/server/processor.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
+	"github.com/mattermost/mattermost-plugin-content-moderation/server/moderation"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/pkg/errors"

--- a/server/processor_test.go
+++ b/server/processor_test.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mattermost/mattermost-plugin-content-moderator/server/moderation"
+	"github.com/mattermost/mattermost-plugin-content-moderation/server/moderation"
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/pkg/errors"


### PR DESCRIPTION
## Overview

This PR renames the plugin to Mattermost Content Moderation Plugin. It also drops an out of date section of the README relating to AI plugin integration.